### PR TITLE
User Password confirmation is hitting the database

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ Client Unit tests use Mocha, Karma
 Server Integration tests use Cucumber.js and supertest
 
 ### Release Notes
+v1.4.2
+- Fixes issue where password confirm could be persisted in plaintext.
+
 v1.4.1
 - Removed surplus logging
 

--- a/server/models/users.coffee
+++ b/server/models/users.coffee
@@ -43,6 +43,7 @@ module.exports = (dal, options) ->
 
   schema.pre 'save', (next) ->
     user = @
+    @confirm = ""
 
     if not @isModified('password')
       return next()
@@ -89,6 +90,7 @@ module.exports = (dal, options) ->
         callback 'password does not meet minimum requirements', false
 
   update = (id, json, callback) ->
+    delete json.confirm
     crud.findById id, json.systemId, (err, user) ->
       if err
         callback err, null
@@ -111,6 +113,7 @@ module.exports = (dal, options) ->
     crud.findOneBy 'userIds.providerId', id, systemId, callback
 
   findOrCreate = (json, callback) ->
+    delete json.confirm
     findOneByProviderId json.providerId, json.systemId (err, user) ->
       if user
         callback err, user
@@ -128,6 +131,7 @@ module.exports = (dal, options) ->
         callback 'cannot find user'
 
   create = (json, callback) ->
+    delete json.confirm
     crud.findOneBy 'email', json.email, json.systemId , (err, user) ->
       if err and err isnt "Cannot find User"
         callback err, null
@@ -137,6 +141,7 @@ module.exports = (dal, options) ->
         crud.create json, callback
 
   updateQuery = (query, change, callback) ->
+    delete change.confirm
     if not query.systemId?
       callback 'SystemId not specified'
     else


### PR DESCRIPTION
This Github issue is synchronized with Zendesk,

**Zendesk ticket ID:** [110](https://goincremental.zendesk.com/agent/#/tickets/110)
**Priority:** high
**Zendesk assignee:** Support/David Bochenski


**Original ticket content:**

Need to make sure we don't save the confirmation field as it's plaintext
