### PR TITLE
make giUsername directive conditional

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ Client Unit tests use Mocha, Karma
 Server Integration tests use Cucumber.js and supertest
 
 ### Release Notes
+v1.4.3
+- giUsername directive now optionally evaluates an angular expression, which causes
+the validation to only be tested if the expression evaluates to true. (if there is
+no expression supplied then the directive works as before, and runs the validation.)
+
 v1.4.2
 - Fixes issue where password confirm could be persisted in plaintext.
 

--- a/client/directives/usernameValidator.coffee
+++ b/client/directives/usernameValidator.coffee
@@ -1,6 +1,6 @@
 angular.module('gi.security').directive 'giUsername'
-, ['giUser', '$q'
-, (User, $q) ->
+, ['giUser', '$q', '$parse'
+, (User, $q, $parse) ->
   restrict: 'A'
   require: 'ngModel'
   compile: (elem, attrs) ->
@@ -10,13 +10,22 @@ angular.module('gi.security').directive 'giUsername'
       $viewValue = () ->
         ngModelController.$viewValue
 
+      requiredGetter = $parse attrs.giUsername
+
+      $scope.$watch 'item.register', (newVal) ->
+        ngModelController.$$parseAndValidate()
+
       ngModelController.$asyncValidators.giUsername = (modelValue, viewValue) ->
         deferred = $q.defer()
-        User.isUsernameAvailable(modelValue).then (valid) ->
-          if valid
-            deferred.resolve()
-          else
-            deferred.reject()
+        if requiredGetter($scope)
+          User.isUsernameAvailable(modelValue).then (valid) ->
+            if valid
+              deferred.resolve()
+            else
+              deferred.reject()
+        else
+          deferred.resolve()
+
         deferred.promise
 
     linkFn


### PR DESCRIPTION
It would be good if the giUsername directive could evaluate an angular expression and only run the tests if that expression evaluates to true.

Why?  What if you want the same form for login / registration.  In the case of login, you don't want to check for duplicate e-mails, in the case of register you do.

